### PR TITLE
Added bzip2 to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ With this script it will be easy to update to phpMyAdmin's latest version. Direc
 ## Requirements
 - wget
 - tar
+- bzip2
 
 ## Installation
 Copy the script to any location of your machine.   


### PR DESCRIPTION
bzip2 is needed to extract .tar.bz2 archives. If not installed, the extraction won't work and does mess up the phpMyAdmin folder:

root@test:~# tar xjf phpMyAdmin-4.0.0-all-languages.tar.bz2
tar (child): bzip2: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
